### PR TITLE
Changes for packaging-friendliness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.vo
+*.glob
+*.v.d
+*.aux
+*.vio
+Makefile.coq
+Makefile.coq.bak
+Makefile.coq.conf
+.coqdeps.d
+*~
+.coq-native/

--- a/opam
+++ b/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/chdoc/coq-reglang"
+dev-repo: "https://github.com/chdoc/coq-reglang.git"
+bug-reports: "https://github.com/chdoc/coq-reglang/issues"
+license: "CeCILL-B"
+
+build: [ make "-j%{jobs}%" "-C" "theories" ]
+install: [ make "-C" "theories" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/RegLang'" ]
+depends: [
+  "coq" {>= "8.6" & < "8.9~"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.8~"}
+]
+
+tags: [
+  "keyword:regular languages"
+  "keyword:regular expressions"
+  "keyword:kleene algebra"
+  "category:Computer Science/Formal Languages Theory and Automata"
+]
+
+authors: [
+  "Christian Doczkal <>"
+  "Gert Smolka <>"
+]

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
-version: "dev"
-maintainer: "palmskog@gmail.com"
+version: "1.0"
+maintainer: "Christian Doczkal <christian.doczkal@ens-lyon.fr>"
 
 homepage: "https://github.com/chdoc/coq-reglang"
 dev-repo: "https://github.com/chdoc/coq-reglang.git"
@@ -18,11 +18,13 @@ depends: [
 tags: [
   "keyword:regular languages"
   "keyword:regular expressions"
-  "keyword:kleene algebra"
+  "keyword:finite automata"
+  "keyword:two-way automata"
+  "keyword:monadic second-order logic"
   "category:Computer Science/Formal Languages Theory and Automata"
 ]
 
 authors: [
-  "Christian Doczkal <>"
+  "Christian Doczkal <christian.doczkal@ens-lyon.fr>"
   "Gert Smolka <>"
 ]

--- a/theories/Makefile
+++ b/theories/Makefile
@@ -1,16 +1,17 @@
-COQVERSION=$(shell coqc -v | grep version | cut -d' ' -f 6 )
-
 all: Makefile.coq
-	+make -f Makefile.coq all
+	+$(MAKE) -f Makefile.coq all
 
 html: Makefile.coq
-	+make -f Makefile.coq html
+	+$(MAKE) -f Makefile.coq html
+
+install: Makefile.coq
+	+$(MAKE) -f Makefile.coq install
 
 clean: Makefile.coq
-	+make -f Makefile.coq clean
+	+$(MAKE) -f Makefile.coq cleanall
 	rm -f Makefile.coq
 
 Makefile.coq: _CoqProject
-	coq_makefile -f _CoqProject -arg -w -arg -notation-overridden -o Makefile.coq
+	coq_makefile -f _CoqProject -o Makefile.coq
 
-.PHONY: all html gallinahtml clean
+.PHONY: all html gallinahtml clean install

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -1,7 +1,7 @@
 -R . RegLang
--install none
 COQDOCFLAGS = "-R . RegLang -s --external 'http://math-comp.github.io/math-comp/htmldoc/' mathcomp \
 --with-header ../extra/header.html --with-footer ../extra/footer.html --index indexpage --parse-comments"
+-arg "-w -notation-overridden"
 misc.v
 setoid_leq.v
 languages.v


### PR DESCRIPTION
This is a great library, and I depend on it in some of my own Coq projects. However, the most convenient way to handle that dependency would be via an OPAM package in the [Coq OPAM repository](https://github.com/coq/opam-coq-archive). Here are some changes that would make packaging the library straightforward, including a local OPAM file that could be used as a template when submitting the package to the repository (and it can also be used for [local pinning](https://opam.ocaml.org/doc/Usage.html#opam-pin)).

Finally, I included a standard `.gitignore` file for Coq projects.