### PR TITLE
update opam and README.md for Coq 8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository contains the Coq development accompanying the paper:
 
 One of the following:
 
-* [coq-8.8](https://github.com/coq/coq/releases/tag/V8.8.1) + [mathcomp-1.7.0](https://github.com/math-comp/math-comp/releases/tag/mathcomp-1.7.0) (the ssreflect component)
+* [coq-8.9](https://github.com/coq/coq/releases/tag/V8.9.0) + [mathcomp-1.7.0](https://github.com/math-comp/math-comp/releases/tag/mathcomp-1.7.0) (the ssreflect component)
+* [coq-8.8](https://github.com/coq/coq/releases/tag/V8.8.2) + [mathcomp-1.7.0](https://github.com/math-comp/math-comp/releases/tag/mathcomp-1.7.0) (the ssreflect component)
 * [coq-8.7](https://coq.inria.fr/coq-87) + [mathcomp-1.6.4](https://github.com/math-comp/math-comp/releases/tag/mathcomp-1.6.4) (the ssreflect component)
 * [coq-8.6](https://coq.inria.fr/coq-86) + [mathcomp-1.6.1](https://github.com/math-comp/math-comp/releases/tag/mathcomp-1.6.1) (the ssreflect component)
 

--- a/opam
+++ b/opam
@@ -1,17 +1,17 @@
 opam-version: "1.2"
-version: "1.0"
+version: "dev"
 maintainer: "Christian Doczkal <christian.doczkal@ens-lyon.fr>"
 
 homepage: "https://github.com/chdoc/coq-reglang"
 dev-repo: "https://github.com/chdoc/coq-reglang.git"
 bug-reports: "https://github.com/chdoc/coq-reglang/issues"
-license: "CeCILL-B"
+license: "CECILL-B"
 
 build: [ make "-j%{jobs}%" "-C" "theories" ]
 install: [ make "-C" "theories" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/RegLang'" ]
 depends: [
-  "coq" {>= "8.6" & < "8.9~"}
+  "coq" {>= "8.6" & < "8.10~"}
   "coq-mathcomp-ssreflect" {>= "1.6" & < "1.8~"}
 ]
 


### PR DESCRIPTION
Note that having version `dev` in the repository OPAM file is convenient for local pinning (separate from the archive version).  License string is changed to conform to the SPDX standard.