### PR TITLE
add From RegLang to requires, switch to -Q in _CoqProject

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,4 @@
--R theories RegLang
+-Q theories RegLang
 -arg -w -arg -notation-overridden
 -arg -w -arg -duplicate-clear
 theories/misc.v

--- a/theories/dfa.v
+++ b/theories/dfa.v
@@ -1,7 +1,7 @@
 (* Authors: Christian Doczkal and Jan-Oliver Kaiser *)
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import all_ssreflect.
-Require Import misc languages.
+From RegLang Require Import misc languages.
 
 Set Implicit Arguments.
 Unset Printing Implicit Defensive.

--- a/theories/languages.v
+++ b/theories/languages.v
@@ -1,7 +1,7 @@
 (* Authors: Christian Doczkal and Jan-Oliver Kaiser *)
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import all_ssreflect.
-Require Import misc.
+From RegLang Require Import misc.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/minimization.v
+++ b/theories/minimization.v
@@ -2,7 +2,7 @@
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
 From mathcomp Require Import fintype path fingraph finfun finset generic_quotient.
-Require Import misc languages dfa.
+From RegLang Require Import misc languages dfa.
 
 Set Implicit Arguments.
 Unset Printing Implicit Defensive.

--- a/theories/myhill_nerode.v
+++ b/theories/myhill_nerode.v
@@ -1,7 +1,7 @@
 (* Authors: Christian Doczkal and Jan-Oliver Kaiser *)
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import all_ssreflect.
-Require Import misc languages dfa minimization regexp.
+From RegLang Require Import misc languages dfa minimization regexp.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/nfa.v
+++ b/theories/nfa.v
@@ -1,7 +1,7 @@
 (* Authors: Christian Doczkal and Jan-Oliver Kaiser *)
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import all_ssreflect.
-Require Import misc languages dfa.
+From RegLang Require Import misc languages dfa.
 
 Set Implicit Arguments.
 Unset Printing Implicit Defensive.

--- a/theories/regexp.v
+++ b/theories/regexp.v
@@ -1,7 +1,7 @@
 (* Authors: Christian Doczkal and Jan-Oliver Kaiser *)
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import all_ssreflect.
-Require Import setoid_leq misc languages dfa nfa.
+From RegLang Require Import setoid_leq misc languages dfa nfa.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/shepherdson.v
+++ b/theories/shepherdson.v
@@ -2,7 +2,7 @@
 (* Distributed under the terms of CeCILL-B. *)
 From Coq Require Import Omega.
 From mathcomp Require Import all_ssreflect.
-Require Import misc setoid_leq languages dfa myhill_nerode two_way.
+From RegLang Require Import misc setoid_leq languages dfa myhill_nerode two_way.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/two_way.v
+++ b/theories/two_way.v
@@ -1,7 +1,7 @@
 (* Authors Christian Doczkal and Jan-Oliver Kaiser *)
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import all_ssreflect.
-Require Import misc languages dfa regexp myhill_nerode.
+From RegLang Require Import misc languages dfa regexp myhill_nerode.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/vardi.v
+++ b/theories/vardi.v
@@ -1,7 +1,7 @@
 (* Author: Christian Doczkal *)
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import all_ssreflect.
-Require Import misc languages nfa two_way.
+From RegLang Require Import misc languages nfa two_way.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/wmso.v
+++ b/theories/wmso.v
@@ -1,7 +1,7 @@
 (* Author: Christian Doczkal *)
 (* Distributed under the terms of CeCILL-B. *)
 From mathcomp Require Import all_ssreflect.
-Require Import misc languages dfa nfa regexp.
+From RegLang Require Import misc languages dfa nfa regexp.
 
 Set Implicit Arguments.
 Unset Printing Implicit Defensive.


### PR DESCRIPTION
To my knowledge, it is recommended best practice to use `-Q` and qualify all `Require` with `From namespace`. For example, this can help when copying subsets of files into other developments.