### PR TITLE
add proof using annotations for vos and vio

### DIFF
--- a/theories/dfa.v
+++ b/theories/dfa.v
@@ -32,10 +32,10 @@ Fixpoint delta (p : A) x :=
   if x is a :: x' then delta (dfa_trans p a) x' else p.
 
 Lemma delta_cons p a x : delta (dfa_trans p a) x = delta p (a :: x). 
-Proof. by []. Qed.
+Proof using. by []. Qed.
 
 Lemma delta_cat p x y : delta p (x ++ y) = delta (delta p x) y.
-Proof. elim: x p => // a x /= IH p. by rewrite IH. Qed.
+Proof using. elim: x p => // a x /= IH p. by rewrite IH. Qed.
 
 Definition dfa_accept (p : A) x := delta p x \in dfa_fin A.
 
@@ -43,14 +43,14 @@ Definition delta_s w := delta (dfa_s A) w.
 Definition dfa_lang := [pred x | dfa_accept (dfa_s A) x].
 
 Lemma accept_nil p : dfa_accept p [::] = (p \in dfa_fin A). 
-Proof. by []. Qed.
+Proof using. by []. Qed.
 
 Lemma accept_cons (x : A) a w : 
   dfa_accept x (a :: w) = dfa_accept (dfa_trans x a) w.
-Proof. by []. Qed.
+Proof using. by []. Qed.
 
 Lemma delta_lang x : (delta_s x \in dfa_fin A) = (x \in dfa_lang).
-Proof. by []. Qed.
+Proof using. by []. Qed.
 
 Definition accE := (accept_nil,accept_cons).
 
@@ -66,7 +66,7 @@ the propositional variant of regularity is obtained as [inhabited (regular L)]. 
 Definition regular (L : lang char) := { A : dfa | forall x, L x <-> x \in dfa_lang A }.
 
 Lemma regular_ext L1 L2 : regular L2 -> L1 =p L2 -> regular L1.
-Proof. case => A HA B. exists A => w. by rewrite B. Qed.
+Proof using. case => A HA B. exists A => w. by rewrite B. Qed.
 
 (** ** Operations on DFAs 
 
@@ -79,7 +79,7 @@ Definition dfa_void :=
   {| dfa_s := tt; dfa_fin := set0 ; dfa_trans x a := tt |}.
 
 Lemma dfa_void_correct (x: dfa_void) w: ~~ dfa_accept x w.
-Proof. by rewrite /dfa_accept inE. Qed.
+Proof using. by rewrite /dfa_accept inE. Qed.
 
 Section DFAOps.
 
@@ -94,7 +94,7 @@ Definition dfa_compl :=
 
 Lemma dfa_compl_correct w :
   w \in dfa_lang dfa_compl = (w \notin dfa_lang A1).
-Proof.
+Proof using.
   rewrite /dfa_lang !inE {2}/dfa_compl /=.
   by rewrite /dfa_accept inE.
 Qed.
@@ -108,7 +108,7 @@ Definition dfa_op  :=
 
 Lemma dfa_op_correct w :
   w \in dfa_lang dfa_op = op (w \in dfa_lang A1) (w \in dfa_lang A2).
-Proof.
+Proof using.
   rewrite !inE {2}/dfa_op /=. 
   elim: w (dfa_s A1) (dfa_s A2) => [| a w IHw] x y; by rewrite !accE ?inE /=.
 Qed.
@@ -116,30 +116,30 @@ Qed.
 Definition dfa0 := {| dfa_s := tt; dfa_trans q a := tt; dfa_fin := set0 |}.
 
 Lemma dfa0_correct x : x \in dfa_lang dfa0 = false.
-Proof. by rewrite -delta_lang inE. Qed.
+Proof using. by rewrite -delta_lang inE. Qed.
 
 End DFAOps.
 
 Lemma regular_inter (L1 L2 : lang char) :
   regular L1 -> regular L2 -> regular (fun x => L1 x /\ L2 x).
-Proof.
+Proof using.
   move => [A LA] [B LB]. exists (dfa_op andb A B) => x.
   by rewrite dfa_op_correct LA LB (rwP andP).
 Qed.
 
 Lemma regular0 : regular (fun _ : word => False).
-Proof. exists (dfa0) => x. by rewrite dfa0_correct. Qed.
+Proof using. exists (dfa0) => x. by rewrite dfa0_correct. Qed.
 
 Lemma regularU (L1 L2 : lang char) :
   regular L1 -> regular L2 -> regular (fun x => L1 x \/ L2 x).
-Proof.
+Proof using.
   move => [A1 acc_L1] [A2 acc_L2]. exists (dfa_op orb A1 A2) => x.  
   by rewrite dfa_op_correct -(rwP orP) -acc_L1 -acc_L2. 
 Qed.
 
 Lemma regular_bigU (T : eqType) (L : T -> lang char) (s : seq T) : 
   (forall a, a \in s -> regular (L a)) -> regular (fun x => exists2 a, a \in s & L a x). 
-Proof.
+Proof using.
   elim: s => //. 
   - move => _. apply: regular_ext regular0 _. by split => // [[a]]. 
   - move => a s IH /all1sT [H1 H2]. 
@@ -157,21 +157,21 @@ Section CutOff.
   Hypothesis RC_f : forall x y a, f x = f y -> f (x++[::a]) = f (y++[::a]).
 
   Lemma RC_seq x y z : f x = f y -> f (x++z) = f (y++z).
-  Proof.
+  Proof using RC_f.
     elim: z x y => [|a z IHz] x y; first by rewrite !cats0.
     rewrite -(cat1s a) (catA x [::a]) (catA y [::a]). move/(RC_f a). exact: IHz.
   Qed.
 
   Lemma RC_rep x (i j : 'I_(size x)) :
     i < j -> f (take i x) = f (take j x) -> f (take i x ++ drop j x) = f x.
-  Proof. move => Hij Hfij. rewrite -{5}(cat_take_drop j x). exact: RC_seq. Qed.
+  Proof using RC_f. move => Hij Hfij. rewrite -{5}(cat_take_drop j x). exact: RC_seq. Qed.
 
 
   Definition exseqb (p : pred rT) :=
     [exists n : 'I_#|rT|.+1, exists x : n.-tuple aT, p (f x)].
 
   Lemma exseqP (p : pred rT) : reflect (exists x, p (f x)) (exseqb p).
-  Proof.
+  Proof using RC_f.
     apply: (iffP idP); last case.
     - case/existsP => n. case/existsP => x Hx. by exists x.
     - apply: (size_induction (measure := size)) => x IHx px.
@@ -187,10 +187,10 @@ Section CutOff.
   Qed.
     
   Lemma exseq_dec (p : pred rT) : decidable (exists x, p (f x)).
-  Proof. apply: decP. exact: exseqP. Qed.
+  Proof using RC_f. apply: decP. exact: exseqP. Qed.
 
   Lemma allseq_dec (p : pred rT) : decidable (forall x, p (f x)).
-  Proof.
+  Proof using RC_f.
     case: (exseq_dec (predC p)) => H;[right|left].
     - move => A. case: H => [x /= Hx]. by rewrite A in Hx.
     - move => x. apply/negPn/negP => C. apply: H. by exists x.
@@ -201,12 +201,12 @@ Section CutOff.
   Definition image_type := { a : rT | exseq_dec (pred1 a) }.
 
   Lemma image_fun_proof (x : seq aT) : exseq_dec (pred1 (f x)).
-  Proof. apply/dec_eq. by exists x => /=. Qed.
+  Proof using. apply/dec_eq. by exists x => /=. Qed.
 
   Definition image_fun (x : seq aT) : image_type := Sub (f x) (image_fun_proof x).
 
   Lemma surjective_image_fun : surjective (image_fun).
-  Proof. move => [y Py]. case/dec_eq : (Py) => /= x ?. by exists x. Qed.
+  Proof using. move => [y Py]. case/dec_eq : (Py) => /= x ?. by exists x. Qed.
   
 End CutOff.
 
@@ -220,18 +220,18 @@ Section Emptyness.
 
   Lemma delta_rc x y a : let s := dfa_s A in
     delta s x = delta s y -> delta s (x ++ [::a]) = delta s (y ++ [::a]).
-  Proof. by rewrite /= !delta_cat => <-. Qed.
+  Proof using. by rewrite /= !delta_cat => <-. Qed.
 
   Definition dfa_inhab : decidable (exists x, x \in dfa_lang A) := 
     exseq_dec delta_rc (fun x => x \in dfa_fin A).
   
   Lemma dfa_inhabP : reflect (exists x, x \in dfa_lang A) (dfa_inhab).
-  Proof. apply: (iffP idP); by rewrite dec_eq. Qed.
+  Proof using. apply: (iffP idP); by rewrite dec_eq. Qed.
 
   Definition dfa_empty := allseq_dec delta_rc (fun x => x \notin dfa_fin A).
   
   Lemma dfa_emptyP : reflect (dfa_lang A =i pred0) (dfa_empty).
-  Proof. 
+  Proof using.
     apply: (iffP idP) => [/dec_eq H x|H]; first by rewrite inE /dfa_accept (negbTE (H _)).
     apply/dec_eq => x. by rewrite -[_ \notin _]/(x \notin dfa_lang A) H.
   Qed.
@@ -244,7 +244,7 @@ Definition dfa_equiv A1 A2 := dfa_empty (dfa_op addb A1 A2).
 
 Lemma dfa_equiv_correct A1 A2 :
   reflect (dfa_lang A1 =i dfa_lang A2) (dfa_equiv A1 A2).
-Proof.
+Proof using.
   apply: (iffP (dfa_emptyP _)) => H w.
   - move/negbT: (H w). rewrite !dfa_op_correct -addNb.
     move/addbP. by rewrite negbK.
@@ -255,7 +255,7 @@ Definition dfa_incl A1 A2 := dfa_empty (dfa_op (fun a b => a && ~~ b) A1 A2).
 
 Lemma dfa_incl_correct A1 A2 : 
   reflect {subset dfa_lang A1 <= dfa_lang A2} (dfa_incl A1 A2).
-Proof.
+Proof using.
   apply: (iffP (dfa_emptyP _)) => H w.
   - move/negbT: (H w). rewrite dfa_op_correct -negb_imply negbK.
     by move/implyP.
@@ -279,7 +279,7 @@ Section Preimage.
      dfa_trans x a := delta x (h [:: a]) |}.
 
   Lemma dfa_preimP A : dfa_lang (dfa_preim A) =i preim h (dfa_lang A).
-  Proof. 
+  Proof using h_hom.
     move => w. rewrite !inE /dfa_accept /dfa_preim /=. 
     elim: w (dfa_s A) => [|a w IHw] x /= ; first by rewrite h0.
     by rewrite -[a :: w]cat1s h_hom !delta_cat -IHw.
@@ -316,7 +316,7 @@ Section RightQuotient.
        dfa_fin := [set q | dec_L2 q] |}.
 
   Lemma dfa_quotP x : reflect (quotR x) (x \in dfa_lang dfa_quot).
-  Proof.
+  Proof using acc_L1.
     apply: (iffP idP).
     - rewrite inE /dfa_accept inE. case/dec_eq => y inL2.
       rewrite -delta_cat => H. exists y => //. by rewrite -acc_L1.
@@ -360,10 +360,10 @@ Section LeftQuotient.
 
 
   Lemma A_start_cat x y : (x ++ y \in dfa_lang A) = (y \in dfa_lang (A_start (delta_s A x))).
-  Proof. rewrite inE /delta_s. elim: x (dfa_s A)=> //= a x IH q. by rewrite accE IH. Qed.
+  Proof using. rewrite inE /delta_s. elim: x (dfa_s A)=> //= a x IH q. by rewrite accE IH. Qed.
 
   Lemma regular_quotL_aux : regular quotL.
-  Proof.
+  Proof using A_start acc_L2 dec_L1.
     pose S := [seq q | q <- enum A & dec_L1 q].
     pose L (q:A) := mem (dfa_lang (A_start q)).
     pose R x := exists2 a, a \in S & L a x.
@@ -423,7 +423,7 @@ Section NonRegular.
   Lemma residualP (f : nat -> word char) (L : lang char) :
     (forall n1 n2, residual L (f n1) =p residual L (f n2) -> n1 = n2) ->
     ~ inhabited (regular L).
-  Proof.
+  Proof using.
     move => f_spec [[A E]].
     pose f' (n : 'I_#|A|.+1) := delta_s A (f n).
     suff: injective f' by move/card_leq_inj ; rewrite card_ord ltnn.
@@ -438,25 +438,25 @@ Section NonRegular.
 
   Lemma count_nseq (T : eqType) (c d : T) n :
     count (pred1 c) (nseq n d) = (c == d) * n.
-  Proof.
+  Proof using.
     elim: n => [|n] /=; first by rewrite muln0.
     rewrite [d == c]eq_sym. by case e: (c == d) => /= ->.
   Qed.
 
   Lemma countL n1 n2 : count (pred1 a) (nseq n1 a ++ nseq n2 b) = n1.
-  Proof. by rewrite count_cat !count_nseq (negbTE Hab) eqxx //= mul1n mul0n addn0. Qed.
+  Proof using Hab. by rewrite count_cat !count_nseq (negbTE Hab) eqxx //= mul1n mul0n addn0. Qed.
 
   Lemma countR n1 n2 : count (pred1 b) (nseq n1 a ++ nseq n2 b) = n2.
-  Proof. by rewrite count_cat !count_nseq eq_sym (negbTE Hab) eqxx //= mul1n mul0n. Qed.
+  Proof using Hab. by rewrite count_cat !count_nseq eq_sym (negbTE Hab) eqxx //= mul1n mul0n. Qed.
 
   Lemma Lab_eq n1 n2 : Lab (nseq n1 a ++ nseq n2 b) -> n1 = n2.
-  Proof.
+  Proof using Hab.
     move => [n H].
     by rewrite -[n1](countL _ n2) -{2}[n2](countR n1 n2) H countL countR.
   Qed.
 
   Lemma Lab_not_regular : ~ inhabited (regular Lab).
-  Proof.
+  Proof using Hab.
     pose f n := nseq n a.
     apply: (@residualP f) => n1 n2. move/(_ (nseq n2 b)) => H.
     apply: Lab_eq. apply/H. by exists n2.
@@ -474,13 +474,13 @@ Section Pumping.
   Variable char : finType.
 
   Lemma delta_rep (A : dfa char) (p : A) x i : delta p x = p -> delta p (rep x i) = p.
-  Proof. elim: i => //= i IH H. by rewrite delta_cat H IH. Qed.
+  Proof using. elim: i => //= i IH H. by rewrite delta_cat H IH. Qed.
 
   Lemma pump_dfa (A : dfa char) x y z :
     x ++ y ++ z \in dfa_lang A -> #|A| < size y ->
     exists u v w,
       [/\ ~~ nilp v, y = u ++ v ++ w & forall i, (x ++ u ++ rep v i ++ w ++ z) \in dfa_lang A].
-  Proof.
+  Proof using.
     rewrite -delta_lang => H1 H2.
     have/injectivePn : ~~ injectiveb (fun i : 'I_(size y) => delta (delta_s A x) (take i y)).
       apply: contraL H2 => /injectiveP/card_leq_inj. by rewrite leqNgt card_ord.
@@ -500,7 +500,7 @@ Section Pumping.
       (forall u v w, y = u ++ v ++ w -> ~~ nilp v ->
          exists i, L (x ++ u ++ rep v i ++ w ++ z) -> False))
      -> ~ inhabited (regular L).
-  Proof.
+  Proof using.
     move => H [[A LA]].
     move/(_ #|A|.+1) : H => [x] [y] [z] [size_y [/LA Lxyz]].
     move: (pump_dfa Lxyz size_y) => [u] [v] [w] [Hn Hy Hv] /(_ u v w Hy Hn).
@@ -509,10 +509,10 @@ Section Pumping.
 
   Lemma cat_nseq_eq n1 n2 (a : char) :
     nseq n1 a ++ nseq n2 a = nseq (n1+n2) a.
-  Proof. elim: n1 => [|n1 IHn1] //=. by rewrite -cat1s IHn1. Qed.
+  Proof using. elim: n1 => [|n1 IHn1] //=. by rewrite -cat1s IHn1. Qed.
 
   Example pump_Lab (a b : char) : a != b -> ~ inhabited (regular (Lab a b)).
-  Proof.
+  Proof using.
     move => neq. apply: pumping => k.
     exists [::]. exists (nseq k a). exists (nseq k b). repeat split.
     - by rewrite size_nseq.

--- a/theories/languages.v
+++ b/theories/languages.v
@@ -41,16 +41,16 @@ Section HomDef.
   Hypothesis h_hom : homomorphism.
 
   Lemma h0 : h [::] = [::].
-  Proof.
+  Proof using h_hom.
     apply: size0nil. apply/eqP.
     by rewrite -(eqn_add2r (size (h [::]))) -size_cat -h_hom /=.
   Qed.
 
   Lemma h_seq w : h w = flatten [seq h [:: a] | a <- w].
-  Proof. elim: w => [|a w IHw] /= ; by rewrite ?h0 // -cat1s h_hom IHw. Qed.
+  Proof using h_hom. elim: w => [|a w IHw] /= ; by rewrite ?h0 // -cat1s h_hom IHw. Qed.
 
   Lemma h_flatten vv : h (flatten vv) = flatten (map h vv).
-  Proof.
+  Proof using h_hom.
     elim: vv => //= [|v vv IHvv]; first exact: h0.
     by rewrite h_hom IHvv.
   Qed.
@@ -59,7 +59,7 @@ Section HomDef.
 
   Lemma image_ext L1 L2  w :
     (forall v, L1 v <-> L2 v) -> (image L1 w <-> image L2 w).
-  Proof. by move => H; split; move => [v] [] /H; exists v. Qed.
+  Proof using. by move => H; split; move => [v] [] /H; exists v. Qed.
 
   Definition preimage (L : word char' -> Prop) v :=  L (h v).
 
@@ -104,11 +104,11 @@ Definition star L : dlang char :=
 
 Lemma plusP r s w :
   reflect (w \in r \/ w \in s) (w \in plus r s).
-Proof. rewrite !inE. exact: orP. Qed.
+Proof using. rewrite !inE. exact: orP. Qed.
 
 Lemma concP {L1 L2 : dlang char} {w : word char} :
   reflect (exists w1 w2, w = w1 ++ w2 /\ w1 \in L1 /\ w2 \in L2) (w \in conc L1 L2).
-Proof. apply: (iffP existsP) => [[n] /andP [H1 H2] | [w1] [w2] [e [H1 H2]]].
+Proof using. apply: (iffP existsP) => [[n] /andP [H1 H2] | [w1] [w2] [e [H1 H2]]].
   - exists (take n w). exists (drop n w). by rewrite cat_take_drop -topredE.
   - have lt_w1: size w1 < (size w).+1 by rewrite e size_cat ltnS leq_addr.
     exists (Ordinal lt_w1); subst.
@@ -116,18 +116,18 @@ Proof. apply: (iffP existsP) => [[n] /andP [H1 H2] | [w1] [w2] [e [H1 H2]]].
 Qed.
 
 Lemma conc_cat w1 w2 L1 L2 : w1 \in L1 -> w2 \in L2 -> w1 ++ w2 \in conc L1 L2.
-Proof. move => H1 H2. apply/concP. exists w1. by exists w2. Qed.
+Proof using. move => H1 H2. apply/concP. exists w1. by exists w2. Qed.
 
 Lemma conc_eq (l1: dlang char) l2 l3 l4:
   l1 =i l2 -> l3 =i l4 -> conc l1 l3 =i conc l2 l4.
-Proof.
+Proof using.
   move => H1 H2 w. apply: eq_existsb => n. 
   by rewrite (_ : l1 =1 l2) // (_ : l3 =1 l4).
 Qed.
 
 Lemma starP : forall {L v},
   reflect (exists2 vv, all [predD L & eps] vv & v = flatten vv) (v \in star L).
-Proof.
+Proof using.
 move=> L v;
   elim: {v}_.+1 {-2}v (ltnSn (size v)) => // n IHn [|x v] /= le_v_n.
   by left; exists [::].
@@ -141,20 +141,20 @@ by rewrite -ltnS (leq_trans _ le_v_n) // size_cat !ltnS leq_addl.
 Qed.
 
 Lemma star_cat w1 w2 L : w1 \in L -> w2 \in (star L) -> w1 ++ w2 \in star L.
-Proof.
+Proof using.
   case: w1 => [|a w1] // H1 /starP [vv Ha Hf]. apply/starP.
   by exists ((a::w1) :: vv); rewrite ?Hf //= H1.
 Qed.
 
 Lemma starI (L : dlang char)  vv :
   (forall v, v \in vv -> v \in L) -> flatten vv \in star L.
-Proof.
+Proof using.
   elim: vv => /= [//| v vv IHvv /all1s [H1 H2]].
   exact: star_cat _ (IHvv _).
 Qed.
 
 Lemma star_eq (l1 : dlang char) l2: l1 =i l2 -> star l1 =i star l2.
-Proof.
+Proof using.
   move => H1 w. apply/starP/starP; move => [] vv H3 H4; exists vv => //;
   erewrite eq_all; try eexact H3; move => x /=; by rewrite ?H1 // -?H1.
 Qed.

--- a/theories/misc.v
+++ b/theories/misc.v
@@ -198,7 +198,7 @@ Section Functional.
 
   Lemma term_uniq x y z : functional ->
     terminal y -> terminal z -> connect e x y -> connect e x z -> y = z.
-  Proof. 
+  Proof using.
     move => fun_e Ty Tz /connectP [p] p1 p2 /connectP [q]. 
     elim: p q x p1 p2 => [|a p IH] [|b q] x /=; first congruence.
     - move => _ <-. by rewrite Ty.
@@ -212,7 +212,7 @@ Section Functional.
   Hypothesis f_inv: forall x z, e' (f x) z -> exists y, z = f y. 
 
   Lemma connect_transfer x y : connect e x y = connect e' (f x) (f y).
-  Proof. apply/idP/idP.
+  Proof using T T' e e' f f_eq f_inj f_inv. apply/idP/idP.
     - case/connectP => s.
       elim: s x => //= [x _ -> |z s IH x]; first exact: connect0.
       case/andP => xz pth Hy. rewrite f_eq in xz.

--- a/theories/myhill_nerode.v
+++ b/theories/myhill_nerode.v
@@ -57,17 +57,18 @@ Section DFAtoClassifier.
   Variable (A : dfa char).
 
   Lemma delta_s_right_congruent : right_congruent (delta_s A).
-  Proof. move => u v a H. rewrite /= /delta_s !delta_cat. by f_equal. Qed.
+  Proof using. move => u v a H. rewrite /= /delta_s !delta_cat. by f_equal. Qed.
 
   Lemma delta_s_refines : refines (dfa_lang A) (delta_s A).
-  Proof. move => u v H. rewrite -!delta_lang. by f_equal. Qed.
+  Proof using. move => u v H. rewrite -!delta_lang. by f_equal. Qed.
 
   Definition dfa_to_cf : classifier_for (dfa_lang A) :=
     {| cf_classifier := Classifier (delta_s A);
        cf_congruent := delta_s_right_congruent;
        cf_refines := delta_s_refines |}.
 
-  Lemma dfa_to_cf_size : #|A| = #|classes_of dfa_to_cf|. by []. Qed.
+  Lemma dfa_to_cf_size : #|A| = #|classes_of dfa_to_cf|.
+  Proof using. by []. Qed.
 End DFAtoClassifier.
 
 
@@ -78,10 +79,10 @@ Section ClassifierToDFA.
   Definition imfun_of_surj := @surjective_image_fun _ _ _ (@cf_congruent _ M).
 
   Lemma imfun_of_refines : refines L imfun_of.
-  Proof. move => x y []. exact: cf_refines. Qed.
+  Proof using. move => x y []. exact: cf_refines. Qed.
 
   Lemma imfun_of_congruent : right_congruent imfun_of.
-  Proof.
+  Proof using.
     move => x y a [] /cf_congruent.
     move/(_ a) => /eqP H. exact/eqP.
   Qed.
@@ -92,14 +93,14 @@ Section ClassifierToDFA.
        dfa_trans x a := imfun_of (cr (imfun_of_surj) x ++ [::a]) |}.
 
   Lemma classifier_to_dfa_delta : delta_s classifier_to_dfa =1 imfun_of.
-  Proof.
+  Proof using.
     apply: last_ind => [|w a IHw] //=.
     rewrite /delta_s -cats1 delta_cat -!/(delta_s _ _) IHw.
     apply: imfun_of_congruent. by rewrite crK.
   Qed.
 
   Lemma classifier_to_dfa_correct : dfa_lang classifier_to_dfa =i L.
-  Proof.
+  Proof using.
     move => w. rewrite -delta_lang classifier_to_dfa_delta inE.
     apply: imfun_of_refines. by rewrite crK.
   Qed.
@@ -107,7 +108,7 @@ End ClassifierToDFA.
 
 Lemma classifier_to_dfa_connected L (M : classifier_for L) :
   connected (classifier_to_dfa M).
-Proof. 
+Proof using.
   move => q. exists (cr (@imfun_of_surj _ M) q).
   rewrite -{2}[q](crK (Sf:=(@imfun_of_surj _ M))).
   by rewrite -/(delta_s _ _) classifier_to_dfa_delta.
@@ -127,10 +128,10 @@ Record mgClassifier L := {
     nerodeP : nerode L mg_classifier }.
 
 Lemma mg_right_congruent L (N : mgClassifier L) : right_congruent N.
-Proof. move => u v a /nerodeP H. apply/nerodeP => w. by rewrite -!catA. Qed.
+Proof using. move => u v a /nerodeP H. apply/nerodeP => w. by rewrite -!catA. Qed.
 
 Lemma mg_refines L (N : mgClassifier L) : refines L N.
-Proof. move => u v /nerodeP H. by rewrite -[u]cats0 -[v]cats0. Qed.
+Proof using. move => u v /nerodeP H. by rewrite -[u]cats0 -[v]cats0. Qed.
 
 Definition mg_to_classifier L (N : mgClassifier L) := {|
   cf_congruent := @mg_right_congruent L N;
@@ -147,15 +148,15 @@ Arguments nerodeP [L] N u v: rename.
 Definition mg_to_dfa L (N : mgClassifier L) := classifier_to_dfa N.
 
 Lemma mg_to_dfa_correct L (N : mgClassifier L) : dfa_lang (mg_to_dfa N) =i L.
-Proof. exact: classifier_to_dfa_correct. Qed.
+Proof using. exact: classifier_to_dfa_correct. Qed.
 
 Lemma mg_to_connected L (N : mgClassifier L) : connected (mg_to_dfa N).
-Proof. exact: classifier_to_dfa_connected. Qed.
+Proof using. exact: classifier_to_dfa_connected. Qed.
 
 (** Most general classifier yield minimal automata *)
 
 Lemma mg_minimal (L : dlang char) (M : mgClassifier L) : minimal (mg_to_dfa M).
-Proof.
+Proof using.
   apply/minimalP. split; first exact: mg_to_connected.
   move => p q. split => [coll_pq|->//]. 
   rewrite -[p](crK (Sf := (@imfun_of_surj _ M))).
@@ -168,7 +169,7 @@ Qed.
 (** We can cast mgClassifiers to equivalent languages *)
 
 Lemma mg_eq_proof L1 L2 (N1 : mgClassifier L1) : L1 =i L2 -> nerode L2 N1.
-Proof. move => H0 u v. split => [/nerodeP H1 w|H1].
+Proof using. move => H0 u v. split => [/nerodeP H1 w|H1].
   - by rewrite -!H0.
   - apply/nerodeP => w. by rewrite !H0.
 Qed.
@@ -182,7 +183,7 @@ Section mDFAtoMG.
   Variable MA : minimal A.
 
   Lemma minimal_nerode : nerode (dfa_lang A) (delta_s A).
-  Proof.
+  Proof using MA.
     move => u v. apply: iff_trans (iff_sym (minimal_collapsed MA _ _)) _.
     by split => H w; move: (H w); rewrite -!delta_cat !delta_lang.
   Qed.

--- a/theories/nfa.v
+++ b/theories/nfa.v
@@ -57,7 +57,7 @@ Section EpsilonNFA.
   Definition eps_reach (p : N) := [set q | connect (enfa_trans None) p q].
 
   Lemma lift_accept p q x : q \in eps_reach p -> enfa_accept q x -> enfa_accept p x.
-  Proof.
+  Proof using.
     rewrite inE => /connectP [s]. elim: s p x q => //= [p x q _ -> //| q s IHs p x q'].
     case/andP => pq ? ? H. apply: EnfaNone pq _. exact: IHs H.
   Qed.
@@ -69,7 +69,7 @@ Section EpsilonNFA.
 
   Lemma enfaE x p :
     (enfa_accept p x) <-> (exists2 q : nfa_of, q \in eps_reach p & nfa_accept q x).
-  Proof. split.
+  Proof using. split.
     - elim => {p x} [q H|p a q x H _ [q' Hq1 Hq2]|p p' x].
       + exists q => //. by rewrite inE connect0.
       + exists p => /=; first by rewrite inE connect0.
@@ -82,7 +82,7 @@ Section EpsilonNFA.
   Qed.
 
   Lemma nfa_ofP x : reflect (enfa_lang x) (x \in nfa_lang nfa_of).
-  Proof.
+  Proof using.
     apply: (iffP exists_inP) => [[p Hp1 Hp2]|[s Hs1 /enfaE [p Hp1 Hp2]]].
     - case/bigcupP : Hp1 => s Hs H. exists s => //. by apply/enfaE; exists p.
     - exists p => //. by apply/bigcupP; exists s.
@@ -103,7 +103,7 @@ Definition nfa_to_dfa := {|
 |}.
 
 Lemma nfa_to_dfa_correct : nfa_lang A =i dfa_lang nfa_to_dfa.
-Proof.
+Proof using.
   move => w. rewrite !inE {2}/nfa_to_dfa /=. 
   elim: w (nfa_s _) => [|a x IH] X; rewrite /= accE ?inE.
   - apply/existsP/set0Pn => [] [p] H; exists p; by rewrite inE in H *.
@@ -128,7 +128,7 @@ Definition dfa_to_nfa : nfa := {|
   nfa_trans x a y := dfa_trans x a == y |}.
 
 Lemma dfa_to_nfa_correct : dfa_lang A =i nfa_lang dfa_to_nfa.
-Proof.
+Proof using.
   move => w. rewrite !inE /nfa_s /=. 
   elim: w (dfa_s A) => [|b w IHw] x; rewrite accE /=.
   - apply/idP/existsP => [Fx|[y /andP [/set1P ->]]//]. 
@@ -155,7 +155,7 @@ Definition nfa_char (a:char) :=
      nfa_trans p b q := if (p,q) is (false,true) then (b == a) else false |}.
 
 Lemma nfa_char_correct (a : char) : nfa_lang (nfa_char a) =1 pred1 [:: a].
-Proof. 
+Proof using.
   move => w /=. apply/exists_inP/eqP => [[p]|]. 
   - rewrite inE => /eqP->. case: w => [|b [|c w]] /=; first by rewrite inE.
     + by case/exists_inP => [[/eqP->|//]].
@@ -175,7 +175,7 @@ Definition nfa_plus (N M : nfa) :=
 
 Lemma nfa_plus_correct (N M : nfa) : 
   nfa_lang (nfa_plus N M) =i plus (nfa_lang N) (nfa_lang M).
-Proof.
+Proof using.
   move => w. apply/idP/idP.
   - case/exists_inP => [[s|s]]; rewrite !inE => A B;
     apply/orP;[left|right];apply/exists_inP; exists s => //.
@@ -195,7 +195,7 @@ Definition nfa_eps : nfa :=
   {| nfa_s := [set tt]; nfa_fin := [set tt]; nfa_trans p a q := false |}.
 
 Lemma nfa_eps_correct: nfa_lang (nfa_eps) =i pred1 [::].
-Proof. 
+Proof using.
   move => w. apply/exists_inP/idP. 
   + move => [[]]. case: w => [|a w] //= _. by case/exists_inP.
   + move => /=. rewrite inE=>/eqP->. exists tt; by rewrite /= inE. 
@@ -225,7 +225,7 @@ Lemma enfa_concE (p : enfa_conc) x : enfa_accept p x ->
     | inr p' => nfa_accept p' x
     | inl p' => exists x1 x2, [/\ x = x1 ++ x2, nfa_accept p' x1 & x2 \in nfa_lang A2]
   end.
-Proof.
+Proof using.
   elim => {p x} [[?|?] /imsetP [q] // ? [->] //||].
   - move => [p|p] a [q|q] x //.
     + move => pq _ [x1] [x2] [X1 X2 X3]. exists (a::x1); exists x2; subst; split => //.
@@ -236,7 +236,7 @@ Proof.
 Qed.
 
 Lemma enfa_concIr (p : A2) x : nfa_accept p x -> @enfa_accept enfa_conc (inr p) x.
-Proof.
+Proof using.
   elim: x p => [p Hp|a x IH p /= /exists_inP [q q1 q2]].
   - by constructor; rewrite mem_imset.
   - apply: (@EnfaSome enfa_conc _ _ (inr q)) => //. exact: IH.
@@ -244,14 +244,14 @@ Qed.
 
 Lemma enfa_concIl (p : A1) x1 x2 :
   nfa_accept p x1 -> x2 \in nfa_lang A2 -> @enfa_accept enfa_conc (inl p) (x1++x2).
-Proof.
+Proof using.
   elim: x1 p => /= [p Hp /exists_inP [q q1 q2]|a x1 IH p /exists_inP [q q1 q2] H].
   - apply: (@EnfaNone enfa_conc _ (inr q)). by rewrite /= Hp. exact: enfa_concIr.
   - apply: (@EnfaSome enfa_conc _ _ (inl q)). by rewrite /= q1. exact: IH.
 Qed.
 
 Lemma enfa_concP x : reflect (enfa_lang enfa_conc x) (conc (nfa_lang A1) (nfa_lang A2) x).
-Proof.
+Proof using.
   apply: (iffP (@concP _ _ _ _)) => [[x1] [x2] [X1 [X2 X3]] |].
   - case/exists_inP : X2 => s ? ?. exists (inl s); first by rewrite /enfa_conc /= mem_imset.
     subst. exact: enfa_concIl.
@@ -271,16 +271,16 @@ Definition enfa_star : enfa :=
        end |}.
 
 Lemma enfa_s_None : None \in enfa_s enfa_star.
-Proof. by rewrite inE. Qed.
+Proof using. by rewrite inE. Qed.
 
 Lemma enfa_f_None : None \in enfa_f enfa_star.
-Proof. by rewrite inE. Qed.
+Proof using. by rewrite inE. Qed.
 
 Hint Resolve enfa_s_None enfa_f_None : core.
 
 Lemma enfa_star_cat x1 x2 (p : enfa_star) :
   enfa_accept p x1 -> enfa_lang enfa_star x2 -> enfa_accept p (x1 ++ x2).
-Proof.
+Proof using.
   elim => {p x1}.
   - move => p. rewrite inE => /eqP->. case => q. by rewrite inE => /eqP->.
   - move => p a q x /=. case: p => // p. case: q => // q pq ? IH H. exact: EnfaSome (IH H).
@@ -288,14 +288,14 @@ Proof.
 Qed.
 
 Lemma enfa_starI x (p : A1) : nfa_accept p x -> @enfa_accept enfa_star (Some p) x.
-Proof.
+Proof using.
   elim: x p => /= [p H|a x IH p].
   - apply: (@EnfaNone enfa_star _ None) => //. exact: EnfaFin.
   - case/exists_inP => q q1 /IH. exact: EnfaSome.
 Qed.
 
 Lemma enfa_star_langI x : x \in nfa_lang A1 -> @enfa_accept enfa_star None x.
-Proof.
+Proof using.
   case/exists_inP => s s1 s2.
   apply: (@EnfaNone enfa_star _ (Some s)) => //. exact: enfa_starI.
 Qed.
@@ -304,7 +304,7 @@ Lemma enfa_starE (o : enfa_star) x : enfa_accept o x ->
   if o is Some p
   then exists x1 x2, [/\ x = x1 ++ x2, nfa_accept p x1 & star (nfa_lang A1) x2]
   else star (nfa_lang A1) x.
-Proof.
+Proof using.
   elim => {x o}.
   - move => [q|//]. by rewrite inE; move/eqP.
   - move => [p|] a [q|] x // H acc [x1] [x2] [H1 H2 H3]. exists (a::x1); exists x2.
@@ -316,7 +316,7 @@ Proof.
 Qed.
 
 Lemma enfa_starP x : reflect (enfa_lang enfa_star x) (star (nfa_lang A1) x).
-Proof. apply: (iffP idP).
+Proof using. apply: (iffP idP).
   - case/starP => vv H ->. elim: vv H => /= [_|v vv].
     + exists None => //. exact: EnfaFin.
     + move => IH /andP[/andP [H1 H2] H3]. exists None => //.
@@ -328,11 +328,11 @@ Qed.
 Definition nfa_conc := nfa_of (enfa_conc).
 
 Lemma nfa_conc_correct : nfa_lang nfa_conc =i conc (nfa_lang A1) (nfa_lang A2).
-Proof. move => x. apply/nfa_ofP/idP => ?;exact/enfa_concP. Qed.
+Proof using. move => x. apply/nfa_ofP/idP => ?;exact/enfa_concP. Qed.
 
 Definition nfa_star := nfa_of (enfa_star).
 Lemma nfa_star_correct : nfa_lang nfa_star =i star (nfa_lang A1).
-Proof. move => x. apply/nfa_ofP/idP => ?;exact/enfa_starP. Qed.
+Proof using. move => x. apply/nfa_ofP/idP => ?;exact/enfa_starP. Qed.
 
 End eNFAOps.
 
@@ -346,7 +346,7 @@ Section NFARun.
     | runS a p q x r & q \in nfa_trans p a : nfa_run x q r -> nfa_run (a::x) p (q::r).
 
   Lemma nfa_acceptP x p : reflect (exists r, nfa_run x p r) (nfa_accept p x).
-  Proof.
+  Proof using.
     apply: (iffP idP) => [|[r]].
     - elim: x p => [|a x IHx] p /=; first by exists [::]; constructor.
       case/exists_inP => q p1 p2. case (IHx q p2) => r ?. by exists (q::r); constructor.
@@ -355,21 +355,21 @@ Section NFARun.
   Qed.
 
   Lemma run_size x r p : nfa_run x p r -> size x = size r.
-  Proof. by elim => // {r p x} a p q r x _ _ /= ->. Qed.
+  Proof using. by elim => // {r p x} a p q r x _ _ /= ->. Qed.
 
   Lemma nfaP x : reflect (exists s r, s \in nfa_s M /\ nfa_run x s r) (x \in nfa_lang M).
-  Proof. 
+  Proof using.
     apply: (iffP exists_inP). 
     - case => s ? /nfa_acceptP [r] ?. by exists s; exists r.
     - case => s [r] [? ?]. exists s => //. apply/nfa_acceptP. by exists r.
   Qed.
 
   Lemma run_last x p r : nfa_run x p r -> last p r \in nfa_fin M.
-  Proof. by elim. Qed.
+  Proof using. by elim. Qed.
 
   Lemma run_trans x p r i (Hi : i < size x) : nfa_run x p r -> 
     nth p (p::r) i.+1 \in nfa_trans (nth p (p::r) i) (tnth (in_tuple x) (Ordinal Hi)).
-  Proof.
+  Proof using.
     move => H. elim: H i Hi => {x p r} // a p q x r tr run IH /= [|i] Hi //. 
     rewrite !(set_nth_default q); try by rewrite /= -(run_size run) // ltnW. 
     rewrite {1}[nth]lock (tnth_nth a) /=. rewrite ltnS in Hi. 
@@ -385,7 +385,7 @@ Section NFARun.
     (forall i : 'I_(size x), 
        nth s (s::r) i.+1 \in nfa_trans (nth s (s::r) i) (tnth (in_tuple x) i)) ->
     nfa_run x s r.
-  Proof. 
+  Proof using.
     elim: x s r => [|a x IHx ] s r /=.
     - move/eqP => e inF _. rewrite size_eq0 in e. rewrite (eqP e) in inF *. exact: run0.
     - case: r => // p r /eqP /=. rewrite eqSS => /eqP R1 R2 I. 
@@ -402,7 +402,7 @@ End NFARun.
 Definition nfa_inhab (N : nfa) := dfa_inhab (nfa_to_dfa N).
 
 Lemma nfa_inhabP N : reflect (exists w, w \in nfa_lang N) (nfa_inhab N).
-Proof.
+Proof using.
   apply: (iffP (dfa_inhabP _)).
   - move => [x]. rewrite -nfa_to_dfa_correct. by exists x.
   - move => [x ?]. exists x. by rewrite -nfa_to_dfa_correct.
@@ -410,7 +410,7 @@ Qed.
 
 Lemma nfa_regular L :
   regular L <-T->  { N : nfa  | forall x, L x <-> x \in nfa_lang N }.
-Proof.
+Proof using.
   split => [[A]|[N]] H. 
   exists (dfa_to_nfa A) => x. by rewrite -dfa_to_nfa_correct.
   exists (nfa_to_dfa N) => x. by rewrite -nfa_to_dfa_correct.

--- a/theories/shepherdson.v
+++ b/theories/shepherdson.v
@@ -64,10 +64,10 @@ Section NFA2toAFA.
   Arguments srel : clear implicits.
 
   Lemma srel_step k w : subrel (srel k w) (step M w).
-  Proof. by move => c d /= => /andP[->]. Qed.
+  Proof using. by move => c d /= => /andP[->]. Qed.
 
   Lemma srel_step_max x : srel (size x).+2 x =2 step M x.
-  Proof. move => c d /=. by rewrite /srel neq_ltn ltn_ord orbT andbT. Qed.
+  Proof using. move => c d /=. by rewrite /srel neq_ltn ltn_ord orbT andbT. Qed.
 
   Definition Tab x : table := 
     ([set q | connect (srel (size x).+1 x) (nfa2_s M, ord1) (q,ord_max)], 
@@ -80,18 +80,18 @@ Section NFA2toAFA.
 
   Lemma srelLR k x p i q j : srel k x (p,i) (q,j) -> 
     j.+1 = i :> nat \/ j = i.+1 :> nat.
-  Proof. move/srel_step. case/orP => /andP [_ /eqP ->]; tauto. Qed.
+  Proof using. move/srel_step. case/orP => /andP [_ /eqP ->]; tauto. Qed.
 
   Lemma srel1 k x c d : srel k x c d -> d.2 <= c.2.+1.
-  Proof. move: c d => [p i] [q j] /srelLR [<-|->] //=. by somega. Qed.
+  Proof using. move: c d => [p i] [q j] /srelLR [<-|->] //=. by somega. Qed.
 
   Lemma srelSr k' k x (c d : nfa2_config M x) : c.2 < k ->
     srel k x c d = srel (k+k') x c d. 
-  Proof. move => lt_k. by rewrite /srel !neq_ltn ltn_addr lt_k ?orbT. Qed.
+  Proof using. move => lt_k. by rewrite /srel !neq_ltn ltn_addr lt_k ?orbT. Qed.
 
   Lemma srelS k x p q (i j : pos x) m : i <= k ->
      connect (srel k x) (p,i) (q,j) -> connect (srel (k+m) x) (p,i) (q,j).
-  Proof. 
+  Proof using.
     move => H /connectP [cs]. 
     elim: cs p i H => [/= p i H _ [-> ->] //|[p' i'] cs IH p i H /= /andP [s pth] l].
     have Hk: i < k. case/andP : s => _ /= s. by rewrite ltn_neqAle H eq_sym s.
@@ -102,7 +102,7 @@ Section NFA2toAFA.
   Lemma srel_mid_path (k k' : nat) x (i j : pos x) (p q : M) cs : 
     i <= k <= j -> path (srel k' x) (p,i) cs -> (q,j) = last (p,i) cs -> 
     exists p' cl cr, [/\ cs = cl ++ cr, (p',inord k) = last (p,i) cl & path (srel k x) (p,i) cl].
-  Proof.  
+  Proof using.
     move: cs p i. apply: (size_induction (measure := size)) => cs IH p i /andP [H1 H2].
     case: (boolP (i == k :> nat)) => Ei.
     - exists p. exists [::]. exists cs. by rewrite -[i]inord_val (eqP Ei).
@@ -119,7 +119,7 @@ Section NFA2toAFA.
   Lemma srel_mid (k k' : nat) x (i j : pos x) (p q : M) : i <= k <= j -> k <= k' ->
     reflect (exists2 p', connect (srel k x) (p,i) (p',inord k) & connect (srel k' x) (p',inord k) (q,j))
             (connect (srel k' x) (p,i) (q,j)).
-  Proof.
+  Proof using.
     move => H X. apply: (iffP idP).
     - case/connectP => cs c1 c2. case: (srel_mid_path H c1 c2) => [p'] [cl] [cr] [Ecs L C].
       subst cs. rewrite cat_path last_cat -L in c1 c2. case/andP : c1 => ? c1. exists p'.
@@ -130,7 +130,7 @@ Section NFA2toAFA.
 
   Lemma readL x z (p:M) (k : pos x) : k != (size x).+1 :> nat -> 
     read p (inord k : pos (x++z)) = read p k. 
-  Proof.
+  Proof using.
     move => Hk. rewrite /read. case: (ord2P k) => [/eqP->|E|i Hi].
     - by rewrite /= -inord0 ord2P0.
     - apply: contraN Hk. by rewrite (eqP E). 
@@ -147,7 +147,7 @@ Section NFA2toAFA.
 
     Lemma srelL (i j : pos x) p q : 
       srel (size x).+1 x (p,i) (q,j) = srel (size x).+1 (x++z) (p,inord i) (q,inord j).
-    Proof.
+    Proof using.
       case: (boolP (i == (size x).+1 :> nat)) => Hi. 
       - rewrite /srel (eqP Hi) /= inordK ?eqxx //= ?andbF //; somega.
       - have Hi' : i < (size x).+1. by rewrite ltn_neqAle Hi -ltnS ltn_ord.
@@ -158,7 +158,7 @@ Section NFA2toAFA.
     Lemma runL (i j : pos x) p q :
       connect (srel (size x).+1 x) (p,i) (q,j) =
       connect (srel (size x).+1 (x++z)) (p,inord i) (q,inord j).
-    Proof.
+    Proof using.
       pose f (c : nfa2_config M x) : nfa2_config M (x ++ z) := (c.1, inord c.2).
       rewrite -[(p,inord i)]/(f (p,i)) -[(q,inord j)]/(f (q,j)).
       apply: connect_transfer => //.
@@ -177,18 +177,18 @@ Section NFA2toAFA.
 
     Lemma Tab1P q : q \in (Tab x).1 
         <-> connect (srel (size x).+1 (x++z)) (nfa2_s M,ord1) (q,inord (size x).+1).
-    Proof. by rewrite /Tab inE runL /= -[ord1]inord_val. Qed.
+    Proof using. by rewrite /Tab inE runL /= -[ord1]inord_val. Qed.
 
     Lemma Tab2P p q : (p,q) \in (Tab x).2
         <-> connect (srel (size x).+1 (x++z)) (p,inord (size x)) (q,inord (size x).+1). 
-    Proof. by rewrite inE runL /= inordK. Qed.
+    Proof using. by rewrite inE runL /= inordK. Qed.
 
     (** Dually, steps on the right of [x++z] do not depend on [x], if they do not
     cross the boundary between [x] and [z]. *)
 
     Lemma readR (q:M) k : k != 0 -> k < (size z).+2 ->
        read q (inord k : pos z) = read q (inord (size x + k) : pos (x++z)).
-    Proof.
+    Proof using.
       move => Hk0 Hk. rewrite /read. case: (ord2P _) => [H|H|i Hi].
       - apply: contraN Hk0. 
         move/eqP/(f_equal (@nat_of_ord _)) : H => /=. by rewrite inordK // => ->.
@@ -202,7 +202,7 @@ Section NFA2toAFA.
     Lemma srelR (m k k' : nat) p p' : k != 0 -> k < (size z).+2 -> k' < (size z).+2 ->
         srel ((size x).+1 + m) (x++z) (p,inord (size x + k)) (p',inord (size x + k'))
       = srel m.+1 z (p,inord k) (p',inord k').
-    Proof.
+    Proof using.
       move => Hk0 Hk Hk'. rewrite /srel /= !inordK ?addSnnS ?eqn_add2l //; somega.
       case: (_ != _); rewrite ?andbT ?andbF // /step -?readR //. 
       rewrite !inordK //; somega. by rewrite -!addnS !eqn_add2l.
@@ -211,7 +211,7 @@ Section NFA2toAFA.
     Lemma srelRE m k p c : k < (size z).+2 -> k != 0 -> 
       srel m (x++z) (p,inord (size x + k)) c -> 
       exists q k', k' < (size z).+2 /\ c = (q,inord (size x + k')).
-    Proof.
+    Proof using.
       move: k c => [//|k] [q j] Hk _ /srelLR [/eqP C|/eqP C];
         exists q; rewrite inordK addnS ?eqSS in C; somega.
       - exists k. by rewrite ltnW // -[j]inord_val (eqP C).
@@ -232,7 +232,7 @@ Section NFA2toAFA.
     Tab x = Tab y -> i <= (size z).+1 -> 0 < j <= (size z).+1 ->
     connect (srel ((size x).+1 + k) (x++z)) (p,inord (size x + i)) (q,inord (size x + j)) ->
     connect (srel ((size y).+1 + k) (y++z)) (p,inord (size y + i)) (q,inord (size y + j)).
-  Proof.
+  Proof using.
     move => Tab_eq Hi /andP [Hj0 Hj]. case/connectP => cs. move: cs i Hi p.
     apply: (size_induction (measure := size)) => /= cs IH i Hi p.
     case: (boolP (i == 0)) => Hi0.
@@ -264,10 +264,10 @@ Section NFA2toAFA.
     yk = (size y).+1 + k -> yi = size y + i -> yj = size y + j ->
     connect (srel xk (x++z)) (p,inord xi) (q,inord xj) ->
     connect (srel yk (y++z)) (p,inord yi) (q,inord yj).
-  Proof. move => ? ? ? ? ? ? ? ? ?. subst. exact: runR. Qed.
+  Proof using. move => ? ? ? ? ? ? ? ? ?. subst. exact: runR. Qed.
 
   Lemma Tab_refines : refines (nfa2_lang M) Tab.
-  Proof.
+  Proof using.
     move => x y E.
     wlog suff W: x y E / (x \in nfa2_lang M) -> (y \in nfa2_lang M).
     { by apply/idP/idP; exact: W. }
@@ -281,7 +281,7 @@ Section NFA2toAFA.
   Qed.
 
   Lemma Tab_rc : right_congruent Tab.
-  Proof.
+  Proof using.
     move => x y a E. 
     have Tab2 : (Tab (x ++ [:: a])).2 = (Tab (y ++ [:: a])).2.
     { apply/setP => [[p q]]. rewrite /Tab !inE /= !inord_max.
@@ -302,7 +302,7 @@ Section NFA2toAFA.
 
   Theorem nfa2_to_dfa : 
     { A : dfa char | dfa_lang A =i nfa2_lang M & #|A| <= 2 ^ (#|M| ^ 2 + #|M|) }.
-  Proof.
+  Proof using.
     exists (classifier_to_dfa (nfa2_to_classifier)); first exact: classifier_to_dfa_correct.
     rewrite card_sub (leqRW (max_card _)) [#|_|]/=.
     by rewrite card_prod expnD mulnC leq_mul //= card_set // card_prod -mulnn. 
@@ -321,19 +321,19 @@ Section DFA2toAFA.
   Variables (char : finType) (M : dfa2 char).
 
   Lemma functional_srel k w : functional (srel M k w).
-  Proof. apply: functional_sub (@srel_step _ _ k w). exact: step_fun. Qed.
+  Proof using. apply: functional_sub (@srel_step _ _ k w). exact: step_fun. Qed.
 
   Lemma term_srel k x q (H: k < (size x).+2) : terminal (srel M k x) (q,inord k).
-  Proof. move => c /=. by rewrite /srel inordK // ?eqxx /= andbF. Qed.
+  Proof using. move => c /=. by rewrite /srel inordK // ?eqxx /= andbF. Qed.
 
   Lemma Tab1_uniq x p q : p \in (Tab M x).1 -> q \in (Tab M x).1 -> p = q.
-  Proof.
+  Proof using.
     rewrite !inE => H1 H2. suff: (p,@ord_max (size x).+1) = (q,ord_max) by case.
     apply: term_uniq H1 H2; rewrite ?inord_max; auto using term_srel, functional_srel.
   Qed.
 
   Lemma Tab2_functional x p q r : (p,q) \in (Tab M x).2 -> (p,r) \in (Tab M x).2 -> q = r.
-  Proof.
+  Proof using.
     rewrite !inE => /= H1 H2. suff: (q,@ord_max (size x).+1) = (r,ord_max) by case.
     apply: term_uniq H1 H2; rewrite ?inord_max; auto using term_srel, functional_srel.
   Qed.
@@ -341,10 +341,10 @@ Section DFA2toAFA.
   Definition Tab' := image_fun (@Tab_rc _ M).
 
   Lemma image_rc : right_congruent Tab'.
-  Proof. move => x y a /Sub_eq E. apply/Sub_eq. exact: Tab_rc. Qed.
+  Proof using. move => x y a /Sub_eq E. apply/Sub_eq. exact: Tab_rc. Qed.
 
   Lemma image_refines : refines (nfa2_lang M) Tab'.
-  Proof. move => x y /Sub_eq E. exact: Tab_refines. Qed.
+  Proof using. move => x y /Sub_eq E. exact: Tab_refines. Qed.
 
   Definition dfa2_to_myhill :=
     {| cf_classifier := Classifier Tab'; 
@@ -352,7 +352,7 @@ Section DFA2toAFA.
        cf_refines := image_refines |}.
 
   Lemma det_range : #|{:image_type (@Tab_rc _ M)}| <= (#|M|.+1)^(#|M|.+1).
-  Proof.
+  Proof using.
     pose table' := (option M * {ffun M -> option M})%type.
     apply: (@leq_trans #|{: table'}|); last by rewrite card_prod card_ffun !card_option expnS.
     pose f (x : image_type (@Tab_rc _ M)) : table' := 
@@ -376,7 +376,7 @@ Section DFA2toAFA.
 
   Theorem dfa2_to_dfa : 
     { A : dfa char | dfa_lang A =i dfa2_lang M & #|A| <= (#|M|.+1)^(#|M|.+1) }.
-  Proof.
+  Proof using.
     exists (classifier_to_dfa (dfa2_to_myhill)); first exact: classifier_to_dfa_correct.
     rewrite card_sub (leqRW (max_card _)). exact: det_range.
   Qed.

--- a/theories/two_way.v
+++ b/theories/two_way.v
@@ -118,21 +118,21 @@ Section DFA2.
   Variable M : dfa2.
 
   Lemma cards_lt1 (T : finType) (A : {set T}) : #|A| <= 1 -> A = set0 \/ exists x, A = [set x].
-  Proof.
+  Proof using.
     move => H. case (posnP #|A|) => H'.
     - left. exact:cards0_eq.
     - right. apply/cards1P. by rewrite eqn_leq H H'.
   Qed.
 
   Lemma read1 x (p:M) (j:pos x) : read p j = set0 \/ exists s : M * dir, read p j = [set s].
-  Proof.
+  Proof using.
     rewrite /read.
     case: (ord2P _) => [||i] _;apply cards_lt1; rewrite ?cardsX ?cards1 ?muln1; 
       by auto using detL, detC, detR, dfa2_det.
   Qed.
 
   Lemma step_fun x : functional (step M x).
-  Proof.
+  Proof using.
     have lr: ((R == L = false)*(L == R = false))%type by done.
     move => [p i] [q j] [r k]. rewrite /step.
     case: (read1 p i) => [ -> |[[q' [|]] -> ]]; first by rewrite !inE.
@@ -175,7 +175,7 @@ Section DFAtoDFA2.
   Lemma nfa2_of_aux (q:A) i : i < (size w).+1 ->
       ((drop i w) \in dfa_accept q) -> 
       [exists f in nfa2_f nfa2_of_dfa, connect (step nfa2_of_dfa w) (q,inord i.+1) (f,ord_max)].
-  Proof.
+  Proof using.
     move eq_m : (n - i) => m. elim: m q i eq_m => [|m IHm] q i /eqP H1 H2.
     - have/eqP -> : i == (size w). by rewrite eqn_leq -ltnS H2 -subn_eq0 H1.
       rewrite drop_size unfold_in -inord_max /= => F. apply/existsP;exists q. rewrite inE F. exact: connect0.
@@ -192,7 +192,7 @@ Section DFAtoDFA2.
   Lemma nfa2_of_aux2 (q f:A) (i : pos w) : i != ord0 ->
     f \in nfa2_f nfa2_of_dfa -> connect (step nfa2_of_dfa w) (q,i) (f,ord_max) -> 
     ((drop i.-1 w) \in dfa_accept q).
-  Proof.
+  Proof using.
   Proof.
     move => H fin_f. case/connectP => p. elim: p i H q => //= [|[q' j] p IHp i Hi q].
     - move => i Hi q _ [<- <-]. rewrite drop_size -topredE /= accept_nil. by rewrite inE in fin_f.
@@ -204,18 +204,18 @@ Section DFAtoDFA2.
   Qed.
 
   Lemma nfa2_of_correct : (w \in dfa_lang A) = (w \in nfa2_lang nfa2_of_dfa).
-  Proof.
+  Proof using.
     apply/idP/idP; rewrite -![_ \in _ A]topredE /=.
     - rewrite -{1}[w]drop0 /nfa2_lang -topredE /= inord1 => H. exact: nfa2_of_aux.
     - rewrite -{2}[w]drop0 -[0]/((@ord1 n).-1). case/exists_inP => p. exact: nfa2_of_aux2.
   Qed.
 
   Lemma nfa2_of_dfa_det : deterministic (nfa2_of_dfa).
-  Proof. split => [p a|p|p]; by rewrite ?cards1 ?cards0. Qed.
+  Proof using. split => [p a|p|p]; by rewrite ?cards1 ?cards0. Qed.
 
   Definition dfa2_of_dfa := DFA2 nfa2_of_dfa_det.
 
   Lemma dfa2_of_correct : (w \in dfa_lang A) = (w \in dfa2_lang dfa2_of_dfa).
-  Proof. exact: nfa2_of_correct. Qed.
+  Proof using. exact: nfa2_of_correct. Qed.
 
 End DFAtoDFA2.

--- a/theories/vardi.v
+++ b/theories/vardi.v
@@ -26,7 +26,7 @@ Section Vardi.
   Arguments run_table x i : clear implicits.
 
   Lemma sub_run x C (i : pos x) : reject_cert C -> {subset run_table x i <= C i}.
-  Proof.
+  Proof using.
     case => T1 T2 T3 p. rewrite inE. case/connectP => cs. 
     elim/last_ind: cs p i => /= [p i _|cs c IH p i]; first by case => -> ->. 
     rewrite rcons_path last_rcons [last _ _]surjective_pairing => /andP [pth stp] E. subst.
@@ -34,7 +34,7 @@ Section Vardi.
   Qed.
 
   Lemma dfa2Pn x : reflect (exists T, @reject_cert x T) (x \notin nfa2_lang M).
-  Proof. apply: introP => [H|].
+  Proof using. apply: introP => [H|].
     - exists (run_table x) ; split; first by rewrite inE ?connect0.
       + apply/pred0P => q. rewrite !inE. apply: contraNF H => C.
         by apply/existsP; exists q.
@@ -62,7 +62,7 @@ Section Vardi.
        nfa_trans X a Y := (X.2 == Y.1) && comp a X.1 X.2 Y.2 |}.
 
   Lemma nfa_ofP x : reflect (exists T, @reject_cert x T) (x \in nfa_lang nfa_of). 
-  Proof. apply: (iffP nfaP). 
+  Proof using. apply: (iffP nfaP).
     - move => [s] [r] [Hp Hr].
       pose T (i : pos x) := if i:nat is i'.+1 then (nth s (s::r) i').2 else (nth s (s::r) 0).1.
       have T_comp (j : 'I_(size x)) :  
@@ -120,6 +120,6 @@ Section Vardi.
   Qed.
         
   Lemma nfa_of_correct : nfa_lang nfa_of =i [predC (nfa2_lang M) ].
-  Proof. move => w. rewrite !inE. apply/idP/dfa2Pn; by move/nfa_ofP. Qed.
+  Proof using. move => w. rewrite !inE. apply/idP/dfa2Pn; by move/nfa_ofP. Qed.
 End Vardi.
 

--- a/theories/wmso.v
+++ b/theories/wmso.v
@@ -91,11 +91,11 @@ Section Language.
 
   Lemma I_of_vev_max k (a:char) w: 
     k \in I_of (vec_of w) (enum_rank a) -> k < size w.
-  Proof. by rewrite /vec_of /I_of mem_filter mem_iota add0n size_map => /andP[_]. Qed.
+  Proof using. by rewrite /vec_of /I_of mem_filter mem_iota add0n size_map => /andP[_]. Qed.
     
   Lemma I_of_vecP k a w: k < size w -> 
     (k \in I_of (vec_of w) (enum_rank a) = (nth a w k == a)).
-  Proof.
+  Proof using.
     move => H. rewrite /vec_of /I_of mem_filter mem_iota add0n size_map /=. 
     rewrite (nth_map a) // H andbT. 
     rewrite (nth_map (enum_rank a)) ?size_tuple ?ltn_ord //.
@@ -107,10 +107,10 @@ Section Language.
   Definition mso_lang s := fun w => vec_lang s (vec_of w).
 
   Lemma vec_of_hom : homomorphism vec_of.
-  Proof. exact: map_cat. Qed.
+  Proof using. exact: map_cat. Qed.
 
   Lemma mso_preim s : mso_lang s =p preimage vec_of (@vec_lang #|char| s).
-  Proof. done. Qed.
+  Proof using. done. Qed.
   
 End Language.
 
@@ -764,7 +764,7 @@ Section NFAtoMSO.
 
   Lemma sat_max (w : word T)  m : 
     cons [:: m] (I_of (vec_of w)) |= max <-> m = size w.
-  Proof.
+  Proof using.
     split.
     - move/sat_all1 => B.
       apply/eqP. rewrite eqn_leq [_ <= m]leqNgt [m <= _]leqNgt.
@@ -800,7 +800,7 @@ Section NFAtoMSO.
   Lemma sat_part X I k : 
     I X =i [:: k] -> 
     I |= part X <-> forall n, n <= k -> exists! q:A, n \in I (rank q).
-  Proof.
+  Proof using.
     move => H0. split.
     - move => H1 m Hm. move/sat_all1 : H1 => /(_ m) /sat_imp. case/(_ _)/Wrap. 
       + rewrite sat_leq ; first apply Hm; done.
@@ -833,7 +833,7 @@ Section NFAtoMSO.
                                        k \in I (rank a) /\ 
                                        k \in tnth Ns (rank p) /\ 
                                        k.+1 \in tnth Ns (rank q)).
-  Proof.
+  Proof using.
     split.
     - move => H k lt_m. move/sat_all1/(_ k.+1) : H. move/sat_all1/(_ k).
       rewrite 2!sat_imp. case/(_ _ _)/Wrap.
@@ -863,7 +863,7 @@ Section NFAtoMSO.
   
   Lemma sat_init (Ns : n.-tuple (seq nat)) I : 
     cat Ns I |= init <-> exists2 q, q \in nfa_s A & 0 \in tnth Ns (rank q).
-  Proof.
+  Proof using.
     split.
     - move/sat_all1/(_ 0)/sat_imp. case/(_ _)/Wrap; first exact/sat_zero.
       case/sat_orE => s. rewrite mem_enum /= => B /sub1P C. exists s => //.
@@ -879,7 +879,7 @@ Section NFAtoMSO.
   Lemma sat_accept (Ns : n.-tuple (seq nat)) m I : 
     cat Ns (cons [:: m] I) |= accept n <-> 
     exists2 q, q \in nfa_fin A & m \in tnth Ns (rank q).
-  Proof.
+  Proof using.
     split.
     - case/sat_orE => q. 
       rewrite mem_enum /= cat_size ?cat_prefix // -tnth_nth.
@@ -896,7 +896,7 @@ Section NFAtoMSO.
 
 
   Theorem form_ofP w : reflect (@mso_lang T form_of w) (w \in nfa_lang A).
-  Proof.
+  Proof using.
     apply: (iffP nfaP).
     - move =>[s] [r] [r1 r2].
       rewrite /mso_lang /vec_lang sat_ex1. exists (size w). 


### PR DESCRIPTION
On my machine, `make -j3` now takes almost twice as long as `make -j3 vos`.