### PR TITLE
switch to dune in OPAM file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
-opam: &OPAM
-  language: minimal
-  sudo: required
+os: linux
+dist: bionic
+language: shell
+
+.opam: &OPAM
+  language: shell
   services: docker
   install: |
     # Prepare the COQ container
@@ -30,12 +33,12 @@ opam: &OPAM
   - docker stop COQ  # optional
   - echo -en 'travis_fold:end:script\\r'
 
-nix: &NIX
+.nix: &NIX
   language: nix
   script:
   - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
-matrix:
+jobs:
   include:
 
   # Test supported versions of Coq via Nix

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ opam install coq-reglang
 To instead build and install manually, do:
 
 ``` shell
-git clone https://github.com/coq-community/reglang
+git clone https://github.com/coq-community/reglang.git
 cd reglang
 make   # or make -j <number-of-cores-on-your-machine>
 make install

--- a/coq-reglang.opam
+++ b/coq-reglang.opam
@@ -16,9 +16,9 @@ automata (deterministic, nondeterministic, one-way, two-way),
 regular expressions, and the logic WS1S. It also contains various
 decidability results and closure properties of regular languages."""
 
-build: [make "-j%{jobs}%"]
-install: [make "install"]
+build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
+  "dune" {>= "2.4"}
   "coq" {(>= "8.10" & < "8.12~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.9" & < "1.11~") | (= "dev")}
 ]

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.3)
+(lang dune 2.4)
 (using coq 0.1)
 (name coq-reglang)


### PR DESCRIPTION
Since dune is bound to replace `coq_makefile` in the medium term for Coq itself and most projects, it makes sense to test building with dune in CI. Note that the Nix CI job still tests/uses `coq_makefile`.