### PR TITLE
Use MathComp Docker images in CI, bump dune

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,10 @@ language: shell
 
 .nix: &NIX
   language: nix
-  nix: 2.3.5
+  install:
+  # for cachix we need travis to be a trusted nix user
+  - echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo systemctl restart nix-daemon
   script:
   - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
@@ -49,22 +52,22 @@ jobs:
 
   # Test supported versions of Coq via OPAM
   - env:
-    - COQ_IMAGE=coqorg/coq:dev
+    - COQ_IMAGE=mathcomp/mathcomp-dev:coq-dev
     - PACKAGE=coq-reglang.dev
     - NJOBS=2
     <<: *OPAM
   - env:
-    - COQ_IMAGE=coqorg/coq:8.12
+    - COQ_IMAGE=mathcomp/mathcomp:1.11.0-coq-8.12
     - PACKAGE=coq-reglang.dev
     - NJOBS=2
     <<: *OPAM
   - env:
-    - COQ_IMAGE=coqorg/coq:8.11
+    - COQ_IMAGE=mathcomp/mathcomp:1.10.0-coq-8.11
     - PACKAGE=coq-reglang.dev
     - NJOBS=2
     <<: *OPAM
   - env:
-    - COQ_IMAGE=coqorg/coq:8.10
+    - COQ_IMAGE=mathcomp/mathcomp:1.9.0-coq-8.10
     - PACKAGE=coq-reglang.dev
     - NJOBS=2
     <<: *OPAM

--- a/coq-reglang.opam
+++ b/coq-reglang.opam
@@ -18,7 +18,7 @@ decidability results and closure properties of regular languages."""
 
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "dune" {>= "2.4"}
+  "dune" {>= "2.5"}
   "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.9" & < "1.12~") | (= "dev")}
 ]

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.4)
-(using coq 0.1)
-(name coq-reglang)
+(lang dune 2.5)
+(using coq 0.2)
+(name reglang)

--- a/meta.yml
+++ b/meta.yml
@@ -49,15 +49,6 @@ supported_coq_versions:
   text: 8.10 or later (use releases for other Coq versions)
   opam: '{(>= "8.10" & < "8.13~") | (= "dev")}'
 
-tested_coq_nix_versions:
-- version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
-
-tested_coq_opam_versions:
-- version: dev
-- version: '8.12'
-- version: '8.11'
-- version: '8.10'
-
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
@@ -65,6 +56,19 @@ dependencies:
   nix: ssreflect
   description: |-
     [MathComp](https://math-comp.github.io) 1.9.0 or later (`ssreflect` suffices)
+
+tested_coq_nix_versions:
+- version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
+
+tested_coq_opam_versions:
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
+- version: '1.11.0-coq-8.12'
+  repo: 'mathcomp/mathcomp'
+- version: '1.10.0-coq-8.11'
+  repo: 'mathcomp/mathcomp'
+- version: '1.9.0-coq-8.10'
+  repo: 'mathcomp/mathcomp'
 
 namespace: RegLang
 

--- a/theories/dune
+++ b/theories/dune
@@ -2,6 +2,4 @@
  (name RegLang)
  (package coq-reglang)
  (synopsis "Representations of regular languages (i.e., regexps, various types of automata, and WS1S) with equivalence proofs, in Coq and MathComp")
- (flags
-   -w -notation-overridden
-   -w -duplicate-clear))
+ (flags -w -notation-overridden -w -duplicate-clear))


### PR DESCRIPTION
This is a CI-only update that should hopefully allow us to test changes more quickly and across a wider range of MathComp versions. We continue to use Dune for OPAM-based CI and coq_makefile for Nix-based CI for some additional "coverage".