### PR TITLE
add minimal Proof using annotations modulo Set Default Proof Using

### DIFF
--- a/theories/dfa.v
+++ b/theories/dfa.v
@@ -157,23 +157,24 @@ Qed.
 Section CutOff.
   Variables (aT rT : finType) (f : seq aT -> rT).
   Hypothesis RC_f : forall x y a, f x = f y -> f (x++[::a]) = f (y++[::a]).
+  Local Set Default Proof Using "RC_f".
 
   Lemma RC_seq x y z : f x = f y -> f (x++z) = f (y++z).
-  Proof using RC_f.
+  Proof.
     elim: z x y => [|a z IHz] x y; first by rewrite !cats0.
     rewrite -(cat1s a) (catA x [::a]) (catA y [::a]). move/(RC_f a). exact: IHz.
   Qed.
 
   Lemma RC_rep x (i j : 'I_(size x)) :
     i < j -> f (take i x) = f (take j x) -> f (take i x ++ drop j x) = f x.
-  Proof using RC_f. move => Hij Hfij. rewrite -{5}(cat_take_drop j x). exact: RC_seq. Qed.
+  Proof. move => Hij Hfij. rewrite -{5}(cat_take_drop j x). exact: RC_seq. Qed.
 
 
   Definition exseqb (p : pred rT) :=
     [exists n : 'I_#|rT|.+1, exists x : n.-tuple aT, p (f x)].
 
   Lemma exseqP (p : pred rT) : reflect (exists x, p (f x)) (exseqb p).
-  Proof using RC_f.
+  Proof.
     apply: (iffP idP); last case.
     - case/existsP => n. case/existsP => x Hx. by exists x.
     - apply: (size_induction (measure := size)) => x IHx px.
@@ -189,10 +190,10 @@ Section CutOff.
   Qed.
     
   Lemma exseq_dec (p : pred rT) : decidable (exists x, p (f x)).
-  Proof using RC_f. apply: decP. exact: exseqP. Qed.
+  Proof. apply: decP. exact: exseqP. Qed.
 
   Lemma allseq_dec (p : pred rT) : decidable (forall x, p (f x)).
-  Proof using RC_f.
+  Proof.
     case: (exseq_dec (predC p)) => H;[right|left].
     - move => A. case: H => [x /= Hx]. by rewrite A in Hx.
     - move => x. apply/negPn/negP => C. apply: H. by exists x.
@@ -435,30 +436,26 @@ Section NonRegular.
   Qed.
 
   Hypothesis (a b : char) (Hab : a != b).
+  Local Set Default Proof Using "Hab".
 
   Definition Lab w := exists n, w = nseq n a ++ nseq n b.
 
-  Lemma count_nseq (T : eqType) (c d : T) n :
-    count (pred1 c) (nseq n d) = (c == d) * n.
-  Proof.
-    elim: n => [|n] /=; first by rewrite muln0.
-    rewrite [d == c]eq_sym. by case e: (c == d) => /= ->.
+  Lemma countL n1 n2 : count (pred1 a) (nseq n1 a ++ nseq n2 b) = n1.
+  Proof. 
+    by rewrite count_cat !count_nseq /= eqxx eq_sym (negbTE Hab) mul1n mul0n addn0. 
   Qed.
 
-  Lemma countL n1 n2 : count (pred1 a) (nseq n1 a ++ nseq n2 b) = n1.
-  Proof using Hab. by rewrite count_cat !count_nseq (negbTE Hab) eqxx //= mul1n mul0n addn0. Qed.
-
   Lemma countR n1 n2 : count (pred1 b) (nseq n1 a ++ nseq n2 b) = n2.
-  Proof using Hab. by rewrite count_cat !count_nseq eq_sym (negbTE Hab) eqxx //= mul1n mul0n. Qed.
+  Proof. by rewrite count_cat !count_nseq /= (negbTE Hab) eqxx //= mul1n mul0n. Qed.
 
   Lemma Lab_eq n1 n2 : Lab (nseq n1 a ++ nseq n2 b) -> n1 = n2.
-  Proof using Hab.
+  Proof.
     move => [n H].
     by rewrite -[n1](countL _ n2) -{2}[n2](countR n1 n2) H countL countR.
   Qed.
 
   Lemma Lab_not_regular : ~ inhabited (regular Lab).
-  Proof using Hab.
+  Proof.
     pose f n := nseq n a.
     apply: (@residualP f) => n1 n2. move/(_ (nseq n2 b)) => H.
     apply: Lab_eq. apply/H. by exists n2.

--- a/theories/languages.v
+++ b/theories/languages.v
@@ -36,26 +36,7 @@ Section Basics.
 End Basics. 
 
 Section HomDef.
-  Variables (char char' : finType).
-  Variable (h : seq char -> seq char').
-
-  Definition homomorphism := forall w1 w2, h (w1 ++ w2) = h w1 ++ h w2.
-  Hypothesis h_hom : homomorphism.
-
-  Lemma h0 : h [::] = [::].
-  Proof using h_hom.
-    apply: size0nil. apply/eqP.
-    by rewrite -(eqn_add2r (size (h [::]))) -size_cat -h_hom /=.
-  Qed.
-
-  Lemma h_seq w : h w = flatten [seq h [:: a] | a <- w].
-  Proof using h_hom. elim: w => [|a w IHw] /= ; by rewrite ?h0 // -cat1s h_hom IHw. Qed.
-
-  Lemma h_flatten vv : h (flatten vv) = flatten (map h vv).
-  Proof using h_hom.
-    elim: vv => //= [|v vv IHvv]; first exact: h0.
-    by rewrite h_hom IHvv.
-  Qed.
+  Variables (char char' : finType) (h : seq char -> seq char').
 
   Definition image (L : word char -> Prop) v := exists w, L w /\ h w = v.
 
@@ -65,6 +46,24 @@ Section HomDef.
 
   Definition preimage (L : word char' -> Prop) v :=  L (h v).
 
+  Definition homomorphism := forall w1 w2, h (w1 ++ w2) = h w1 ++ h w2.
+  Hypothesis h_hom : homomorphism.
+  Local Set Default Proof Using "h_hom".  
+
+  Lemma h0 : h [::] = [::].
+  Proof.
+    apply: size0nil. apply/eqP.
+    by rewrite -(eqn_add2r (size (h [::]))) -size_cat -h_hom /=.
+  Qed.
+
+  Lemma h_seq w : h w = flatten [seq h [:: a] | a <- w].
+  Proof. elim: w => [|a w IHw] /= ; by rewrite ?h0 // -cat1s h_hom IHw. Qed.
+
+  Lemma h_flatten vv : h (flatten vv) = flatten (map h vv).
+  Proof.
+    elim: vv => //= [|v vv IHvv]; first exact: h0.
+    by rewrite h_hom IHvv.
+  Qed.
 
 End HomDef.
 

--- a/theories/languages.v
+++ b/theories/languages.v
@@ -3,6 +3,8 @@
 From mathcomp Require Import all_ssreflect.
 From RegLang Require Import misc.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -41,16 +43,16 @@ Section HomDef.
   Hypothesis h_hom : homomorphism.
 
   Lemma h0 : h [::] = [::].
-  Proof.
+  Proof using h_hom.
     apply: size0nil. apply/eqP.
     by rewrite -(eqn_add2r (size (h [::]))) -size_cat -h_hom /=.
   Qed.
 
   Lemma h_seq w : h w = flatten [seq h [:: a] | a <- w].
-  Proof. elim: w => [|a w IHw] /= ; by rewrite ?h0 // -cat1s h_hom IHw. Qed.
+  Proof using h_hom. elim: w => [|a w IHw] /= ; by rewrite ?h0 // -cat1s h_hom IHw. Qed.
 
   Lemma h_flatten vv : h (flatten vv) = flatten (map h vv).
-  Proof.
+  Proof using h_hom.
     elim: vv => //= [|v vv IHvv]; first exact: h0.
     by rewrite h_hom IHvv.
   Qed.

--- a/theories/minimization.v
+++ b/theories/minimization.v
@@ -4,6 +4,8 @@ From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq choice.
 From mathcomp Require Import fintype path fingraph finfun finset generic_quotient.
 From RegLang Require Import misc languages dfa.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Printing Implicit Defensive.
 Unset Strict Implicit.
@@ -43,19 +45,19 @@ Section Isomopism.
   Definition iso_inv := delta_s A \o cr B_conn.
 
   Lemma delta_iso w x : delta (iso x) w \in dfa_fin B = (delta x w \in dfa_fin A).
-  Proof. by rewrite -{2}[x](crK (Sf := A_conn)) -!delta_cat !delta_lang L_AB. Qed.
+  Proof using L_AB. by rewrite -{2}[x](crK (Sf := A_conn)) -!delta_cat !delta_lang L_AB. Qed.
 
   Lemma delta_iso_inv w x : delta (iso_inv x) w \in dfa_fin A = (delta x w \in dfa_fin B).
-  Proof. by rewrite -{2}[x](crK (Sf := B_conn)) -!delta_cat !delta_lang L_AB. Qed.
+  Proof using L_AB. by rewrite -{2}[x](crK (Sf := B_conn)) -!delta_cat !delta_lang L_AB. Qed.
 
   Lemma can_iso : cancel iso_inv iso.
-  Proof. move => x. apply/B_coll => w. by rewrite delta_iso delta_iso_inv. Qed.
+  Proof using B_coll L_AB. move => x. apply/B_coll => w. by rewrite delta_iso delta_iso_inv. Qed.
 
   Lemma can_iso_inv : cancel iso iso_inv.
-  Proof. move => x. apply/A_coll => w. by rewrite delta_iso_inv delta_iso. Qed.
+  Proof using A_coll L_AB. move => x. apply/A_coll => w. by rewrite delta_iso_inv delta_iso. Qed.
 
   Lemma coll_iso : dfa_iso A B.
-  Proof.
+  Proof using A_coll B_coll A_conn B_conn L_AB.
     exists iso. split.
     - exact: Bijective can_iso_inv can_iso.
     - move => x a. apply/B_coll => w. rewrite -[_ (iso x) a]/(delta (iso x) [::a]).

--- a/theories/misc.v
+++ b/theories/misc.v
@@ -3,6 +3,8 @@
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import all_ssreflect.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -212,7 +214,8 @@ Section Functional.
   Hypothesis f_inv: forall x z, e' (f x) z -> exists y, z = f y. 
 
   Lemma connect_transfer x y : connect e x y = connect e' (f x) (f y).
-  Proof. apply/idP/idP.
+  Proof using f_eq f_inj f_inv.
+    apply/idP/idP.
     - case/connectP => s.
       elim: s x => //= [x _ -> |z s IH x]; first exact: connect0.
       case/andP => xz pth Hy. rewrite f_eq in xz.
@@ -221,7 +224,7 @@ Section Functional.
       elim: s x => //= [x _ /f_inj -> |z s IH x]; first exact: connect0.
       case/andP => xz pth Hy. case: (f_inv xz) => z' ?; subst. 
       rewrite -f_eq in xz. apply: connect_trans (connect1 xz) _. exact: IH.
-  Qed.  
+  Qed.
 End Functional.
 
 Lemma functional_sub (T : finType) (e1 e2 : rel T) : 
@@ -257,7 +260,3 @@ Proof. by rewrite (eqP (xchooseP (Sf x))). Qed.
 
 Lemma dec_eq (P : Prop) (decP : decidable P) : decP <-> P.
 Proof. by case: decP. Qed.
-
-
-
-

--- a/theories/myhill_nerode.v
+++ b/theories/myhill_nerode.v
@@ -3,6 +3,8 @@
 From mathcomp Require Import all_ssreflect.
 From RegLang Require Import misc languages dfa minimization regexp.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -182,7 +184,7 @@ Section mDFAtoMG.
   Variable MA : minimal A.
 
   Lemma minimal_nerode : nerode (dfa_lang A) (delta_s A).
-  Proof.
+  Proof using MA.
     move => u v. apply: iff_trans (iff_sym (minimal_collapsed MA _ _)) _.
     by split => H w; move: (H w); rewrite -!delta_cat !delta_lang.
   Qed.

--- a/theories/nfa.v
+++ b/theories/nfa.v
@@ -3,6 +3,8 @@
 From mathcomp Require Import all_ssreflect.
 From RegLang Require Import misc languages dfa.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Printing Implicit Defensive.
 Unset Strict Implicit.

--- a/theories/regexp.v
+++ b/theories/regexp.v
@@ -3,6 +3,8 @@
 From mathcomp Require Import all_ssreflect.
 From RegLang Require Import setoid_leq misc languages dfa nfa.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -408,7 +410,7 @@ Section Image.
     end.
 
   Lemma re_imageP e v : reflect (image h (re_lang e) v) (v \in re_image e).
-  Proof.
+  Proof using h_hom.
     elim: e v => [||a|e IHe|e1 IHe1 e2 IHe2|e1 IHe1 e2 IHe2] v /=.
     - rewrite inE; constructor. move => [u]. by case.
     - rewrite inE; apply: (iffP eqP) => [-> |[w] [] /eqP -> <-]; last exact: h0.

--- a/theories/shepherdson.v
+++ b/theories/shepherdson.v
@@ -4,6 +4,8 @@ From Coq Require Import Omega.
 From mathcomp Require Import all_ssreflect.
 From RegLang Require Import misc setoid_leq languages dfa myhill_nerode two_way.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -12,7 +14,7 @@ Unset Printing Implicit Defensive.
 
 (** Preliminaries *)
 
-Lemma contraN (b : bool) (P : Prop) : b -> ~~ b -> P. by case b. Qed. 
+Lemma contraN (b : bool) (P : Prop) : b -> ~~ b -> P. Proof. by case b. Qed.
 
 Lemma inord_inj n m : n <= m -> injective (@inord m \o @nat_of_ord n.+1).
 Proof.

--- a/theories/two_way.v
+++ b/theories/two_way.v
@@ -3,6 +3,8 @@
 From mathcomp Require Import all_ssreflect.
 From RegLang Require Import misc languages dfa regexp myhill_nerode.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -192,7 +194,6 @@ Section DFAtoDFA2.
   Lemma nfa2_of_aux2 (q f:A) (i : pos w) : i != ord0 ->
     f \in nfa2_f nfa2_of_dfa -> connect (step nfa2_of_dfa w) (q,i) (f,ord_max) -> 
     ((drop i.-1 w) \in dfa_accept q).
-  Proof.
   Proof.
     move => H fin_f. case/connectP => p. elim: p i H q => //= [|[q' j] p IHp i Hi q].
     - move => i Hi q _ [<- <-]. rewrite drop_size -topredE /= accept_nil. by rewrite inE in fin_f.

--- a/theories/vardi.v
+++ b/theories/vardi.v
@@ -3,6 +3,8 @@
 From mathcomp Require Import all_ssreflect.
 From RegLang Require Import misc languages nfa two_way.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/wmso.v
+++ b/theories/wmso.v
@@ -3,6 +3,8 @@
 From mathcomp Require Import all_ssreflect.
 From RegLang Require Import misc languages dfa nfa regexp.
 
+Set Default Proof Using "Type".
+
 Set Implicit Arguments.
 Unset Printing Implicit Defensive.
 Unset Strict Implicit.


### PR DESCRIPTION
This commit adds `Set Default Proof Using` commands in all files with sections, and minimal `Proof using` annotations to include section hypotheses. This has the following results:

- documents whenever a section hypothesis (in `Prop`) is used in a proof, as per recent guidelines
- makes it worthwhile to use `make vio` or `make vos` on the project (build time is nearly halved)

Finally, I added one missing `Proof` and removed a redundant `Proof`, discoveries that were made on the way.