### PR TITLE
Fix cron in CI, update metadata for 8.14

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,6 +1,10 @@
-name: CI
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+name: Docker CI
 
 on:
+  schedule:
+    - cron: '20 4 * * *'
   push:
     branches:
       - master

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ make install
 
 To generate HTML documentation, run `make coqdoc` and point your browser at `docs/coqdoc/toc.html`.
 
-See also the pregenerated HTML documentation for the [latest release](https://coq-community.github.io/reglang/docs/latest/coqdoc/toc.html).
+See also the pregenerated HTML documentation for the [latest release](https://coq-community.org/reglang/docs/latest/coqdoc/toc.html).
 
 ## File Contents
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -2,6 +2,7 @@
 -arg -w -arg -notation-overridden
 -arg -w -arg -duplicate-clear
 -arg -w -arg -notation-incompatible-format
+-arg -w -arg -deprecated-instance-without-locality
 theories/misc.v
 theories/setoid_leq.v
 theories/languages.v

--- a/coq-reglang.opam
+++ b/coq-reglang.opam
@@ -22,7 +22,7 @@ decidability results and closure properties of regular languages."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.15~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.9" & < "1.13~") | (= "dev")}
 ]
 

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,6 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
 { pkgs ? (import <nixpkgs> {}), coq-version-or-url, shell ? false }:
 
 let

--- a/meta.yml
+++ b/meta.yml
@@ -48,7 +48,7 @@ license:
 
 supported_coq_versions:
   text: 8.10 or later (use releases for other Coq versions)
-  opam: '{(>= "8.10" & < "8.14~") | (= "dev")}'
+  opam: '{(>= "8.10" & < "8.15~") | (= "dev")}'
 
 dependencies:
 - opam:
@@ -94,7 +94,7 @@ documentation: |-
 
   To generate HTML documentation, run `make coqdoc` and point your browser at `docs/coqdoc/toc.html`.
 
-  See also the pregenerated HTML documentation for the [latest release](https://coq-community.github.io/reglang/docs/latest/coqdoc/toc.html).
+  See also the pregenerated HTML documentation for the [latest release](https://coq-community.org/reglang/docs/latest/coqdoc/toc.html).
 
   ## File Contents
 

--- a/theories/dune
+++ b/theories/dune
@@ -2,4 +2,4 @@
  (name RegLang)
  (package coq-reglang)
  (synopsis "Representations of regular languages (i.e., regexps, various types of automata, and WS1S) with equivalence proofs, in Coq and MathComp")
- (flags -w -notation-overridden -w -duplicate-clear -w -notation-incompatible-format -w -omega-is-deprecated))
+ (flags -w -notation-overridden -w -duplicate-clear -w -notation-incompatible-format -w -deprecated-instance-without-locality))


### PR DESCRIPTION
The cronjob introduced in #27 did not get propagated to the CI configuration. This PR fixes that, and also updates some metadata and configuration for 8.14.