### PR TITLE
disable Nix CI for Coq master due to failures

### DIFF
--- a/.github/workflows/nix-action.yml
+++ b/.github/workflows/nix-action.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         overrides:
-          - 'coq = "master"; mathcomp = "master"'
           - 'coq = "8.15"'
           - 'coq = "8.14"'
           - 'coq = "8.13"'

--- a/meta.yml
+++ b/meta.yml
@@ -59,9 +59,6 @@ dependencies:
     [MathComp](https://math-comp.github.io) 1.11.0 or later (`ssreflect` suffices)
 
 tested_coq_nix_versions:
-- coq_version: 'master'
-  extra_dev_dependencies:
-  - nix_name: mathcomp
 - coq_version: '8.15'
 - coq_version: '8.14'
 - coq_version: '8.13'


### PR DESCRIPTION
The Nix CI has started to fail on Coq `master`, which I have reported here: https://github.com/coq-community/coq-nix-toolbox/issues/95

This PR disables this CI for the time being to stop failures here.