### PR TITLE
re-enable MathComp dev in Docker CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
+          - 'mathcomp/mathcomp-dev:coq-dev'
           - 'mathcomp/mathcomp:1.15.0-coq-8.16'
           - 'mathcomp/mathcomp:1.15.0-coq-8.15'
           - 'mathcomp/mathcomp:1.14.0-coq-8.15'

--- a/meta.yml
+++ b/meta.yml
@@ -65,7 +65,8 @@ tested_coq_nix_versions:
 - coq_version: '8.13'
 
 tested_coq_opam_versions:
-- version: 'dev'
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
 - version: '1.15.0-coq-8.16'
   repo: 'mathcomp/mathcomp'
 - version: '1.15.0-coq-8.15'


### PR DESCRIPTION
Now that we have reliably rebuilding images again, we roll back #49 