### PR TITLE
add back mathcomp-dev into Docker CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - 'mathcomp/mathcomp-dev:coq-dev'
           - 'mathcomp/mathcomp:2.0.0-coq-8.17'
           - 'mathcomp/mathcomp:2.0.0-coq-8.16'
       fail-fast: false

--- a/coq-reglang.opam
+++ b/coq-reglang.opam
@@ -22,8 +22,8 @@ decidability results and closure properties of regular languages."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.16" & < "8.18~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "2.0" & < "2.1~") | (= "dev")}
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "2.0"}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -49,16 +49,18 @@ license:
 
 supported_coq_versions:
   text: 8.16 or later (use releases for other Coq versions)
-  opam: '{(>= "8.16" & < "8.18~") | (= "dev")}'
+  opam: '{>= "8.16"}'
 
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "2.0" & < "2.1~") | (= "dev")}'
+    version: '{>= "2.0"}'
   description: |-
     [MathComp](https://math-comp.github.io) 2.0 or later (`ssreflect` suffices)
 
 tested_coq_opam_versions:
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
 - version: '2.0.0-coq-8.17'
   repo: 'mathcomp/mathcomp'
 - version: '2.0.0-coq-8.16'


### PR DESCRIPTION
For more flexibility, remove some opam upper bounds.